### PR TITLE
Honour XDG user download directory

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,5 @@
+;;; Directory Local Variables
+;;; For more information see (info "(emacs) Directory Variables")
+
+((sh-mode . ((indent-tabs-mode . t)
+             (tab-width . 4))))

--- a/bin/scitopdf
+++ b/bin/scitopdf
@@ -5,7 +5,13 @@ echo $(tput setf 2) " ░▄▀▀░▄▀▀░█░▀█▀░▄▀▄▒�
 echo $(tput setf 2) " ▒▄██░▀▄▄░█░▒█▒░▀▄▀░█▀▒▒█▄▀░█▀ " $(tput sgr0)
 
 # Downloads folder [change that to your favorite location]
-destination=$HOME/downloads/scitopdf
+if [ -z "$destination" ]; then
+	if [ -n "$XDG_DOWNLOAD_DIR" ]; then
+		destination="$XDG_DOWNLOAD_DIR"
+	else
+		destination="$HOME/Downloads/scitopdf"
+	fi
+fi
 
 [ -d $destination ] || mkdir -p "$destination" &> /dev/null || \
 	echo -e "$(tput setf 4)Can't create downloads directory to $destination.\nPlease be sure you have permissions.\nPapers will not be stored.$(tput sgr0)"


### PR DESCRIPTION
Depending on the language used on the user’s machine, the default download directory might not be `~/downloads`, which is itself non-standard.

The script should first look up the `XDG_DOWNLOAD_DIR` variable which might hold the name of the user’s default directory --- for instance, French-speaking users of Linux distributions such as Ubuntu have `~/Téléchargements` as their default download directory.

If such a directory does not exist, then the script should fall back to the default download directory in Linux distributions, `~/Downloads`

This commit implements such a behaviour in scitopdf.

It also adds a file-local variable for Emacs users to enforce the use of tabs instead of spaces in indentation.