### PR TITLE
Replace tput calls with variables

### DIFF
--- a/bin/scitopdf
+++ b/bin/scitopdf
@@ -1,8 +1,18 @@
 #!/bin/bash
 #
 
-echo $(tput setf 2) " ░▄▀▀░▄▀▀░█░▀█▀░▄▀▄▒█▀▄░█▀▄▒█▀ " $(tput sgr0)
-echo $(tput setf 2) " ▒▄██░▀▄▄░█░▒█▒░▀▄▀░█▀▒▒█▄▀░█▀ " $(tput sgr0)
+_RED=$(tput setaf 1)
+_GREEN=$(tput setaf 2)
+_YELLOW=$(tput setaf 3)
+_BLUE=$(tput setaf 4)
+_MAGENTA=$(tput setaf 5)
+_CYAN=$(tput setaf 6)
+_WHITE=$(tput setaf 7)
+_RESET=$(tput sgr0)
+_BOLD=$(tput bold)
+
+echo "$_GREEN ░▄▀▀░▄▀▀░█░▀█▀░▄▀▄▒█▀▄░█▀▄▒█▀ "
+echo        " ▒▄██░▀▄▄░█░▒█▒░▀▄▀░█▀▒▒█▄▀░█▀ $_RESET"
 
 # Downloads folder [change that to your favorite location]
 if [ -z "$destination" ]; then
@@ -14,7 +24,7 @@ if [ -z "$destination" ]; then
 fi
 
 [ -d $destination ] || mkdir -p "$destination" &> /dev/null || \
-	echo -e "$(tput setf 4)Can't create downloads directory to $destination.\nPlease be sure you have permissions.\nPapers will not be stored.$(tput sgr0)"
+	echo -e "${_BLUE}Can't create downloads directory to $destination.\nPlease be sure you have permissions.\nPapers will not be stored.$_RESET"
 
 # Quickly check internet connection
 if [[ $OSTYPE == 'darwin'* ]]; then
@@ -72,7 +82,7 @@ change_headers() {
 	#--------------#
 locate_website() {
 	[[ -f /tmp/sci_address ]] && [[ ! $(cat /tmp/sci_address) == "" ]] && site=$(cat /tmp/sci_address) && return
-	echo $(tput bold)"Looking for website..."$(tput sgr0)
+	echo "${_BOLD}Looking for website...$_RESET"
 	site=$(curl -s -LH "" "https://sci-hub.now.sh/" | grep -i https://sci-hub... | grep -i biglink | grep -io https://sci-hub... | head -n 1)
 	if [[ $(echo $(curl -v $site 2>&1) | grep -io "Could not resolve" | tail -n 1) = $(echo "Could not resolve") ]]; then
 		echo -e "Sci-Hub not found. \nCheck https://sci-hub.now.sh\nFor manual website setting, use the -u option"
@@ -89,11 +99,11 @@ change_headers
 if ! [[ $(echo $doi) = "" ]]; then
 	if [[ $(echo $doi | grep -io "doi:") = "doi:" || $(echo $doi | grep -io "doi\.") = "doi." ]]; then
 		doi=$(echo $doi | sed 's/http:\/\///' | grep -io "/.*" | sed 's/\///')
-		echo $(tput bold)"DOI : $(tput sgr0)$doi"
+		echo "${_BOLD}DOI: ${_RESET}$doi"
 	fi
-	echo $(tput bold)"DOI : $(tput sgr0)$doi"
+	echo "${_BOLD}DOI: ${_RESET}$doi"
 else
-	echo $(tput setaf 1)"DOI not found."$(tput sgr0)
+	echo "${_RED}DOI not found.$_RESET"
 	#notify-send "scitopdf" "DOI not found."
 	[[ ! -v listing ]] && exit 1;
 fi
@@ -104,11 +114,11 @@ fi
 paper_search() {
 if ! [[ $(echo "$concatenate") = "" ]]; then
 	change_headers
-	user_search=$(echo $concatenate | sed "s/'/\ /" | sed 's/\ /+/g' | iconv -f utf8 -t ascii//TRANSLIT)
+	user_search=$(echo "$concatenate" | sed "s/'/\ /" | sed 's/\ /+/g' | iconv -f utf8 -t ascii//TRANSLIT)
 	#notify-send "scitopdf" "Looking for '$(echo $user_search | sed 's/+/\ /g')'"
 	# if sci-hub's website in user search, download this specific link:
-	[[ -v listing ]] && echo -e "\n$(tput bold)[Reference $ref_index]$(tput sgr0) $(tput setf 1)$line$(tput sgr0)"
-	if [[ $(echo $user_search | grep -o "$site") = "$site" ]]; then
+	[[ -v listing ]] && echo -e "\n${_BOLD}[Reference $ref_index]${_RESET}${_RED}$line${_RESET}"
+	if [[ $(echo "$user_search" | grep -o "$site") = "$site" ]]; then
 		download_link=$(curl -s "$user_search" | grep -io "http.*\.pdf" | head -n 1)
 		if [[ $download_link = "" ]]; then
 			download_link=$(echo https:)$(curl -s "$user_search" | grep -io "\/\/.*\.pdf" | head -n 1)
@@ -120,7 +130,7 @@ if ! [[ $(echo "$concatenate") = "" ]]; then
 		if [[ $download_link = "" ]]; then
 			download_link=$(echo https:)$(curl -s "$site/$user_search" | grep -io "\/\/.*\.pdf" | head -n 1)
 			if [[ $download_link = "https:" ]]; then
-				echo $(tput setaf 1)"Empty download link. Trying address with Crossref."$(tput sgr0)
+				echo "${_RED}Empty download link. Trying address with Crossref.$_RESET"
 				doi_search
 				download_link=$(curl -s "$site/$doi" | grep -io "http.*\.pdf" | head -n 1)
 				if [[ $download_link = "" ]]; then
@@ -151,7 +161,7 @@ if ! [[ $(echo "$concatenate") = "" ]]; then
 	fi
 
 	if [[ $download_link = "" || $download_link = "https:" ]]; then
-		echo $(tput setaf 1)"Empty download link."$(tput sgr0)
+		echo "${_RED}Empty download link.$_RESET"
 		rm /tmp/scitopdf_curl.txt &>/dev/null
 		unset download_link
 		[[ -v listing ]] && not_found=$(( $not_found + 1 ))
@@ -164,19 +174,19 @@ if ! [[ $(echo "$concatenate") = "" ]]; then
 	if [[ $(echo $filename) == "" ]]; then
 		if [[ $(echo $(curl -s $site/$doi) | grep -io "article not found") = "article not found" ]]; then
 			#notify-send "Paper not available on Sci-Hub."
-			echo $(tput setaf 3)"Paper not available on Sci-Hub."$(tput sgr0)
+			echo "${_YELLOW}Paper not available on Sci-Hub.$_RESET"
 		else
 			#notify-send "Paper not found."
-			echo $(tput setaf 3)"Paper not found.\\nPlease check if your country is not blocking access to Sci-Hub. Use a VPN if possible."$(tput sgr0)
+			echo "${_YELLOW}Paper not found.\\nPlease check if your country is not blocking access to Sci-Hub. Use a VPN if possible.$_RESET"
 			[[ ! -v listing ]] && exit 1;
 		fi
 	else
 		#echo "Downloading '$filename' to '$destination'."
-		echo $(tput bold)"Downloading ..."$(tput sgr0)
+		echo "${_BOLD}Downloading ...$_RESET"
 		#curl "$download_link" --output "$filename"
 		curl "$download_link" --output "$filename" --progress-bar
 		#notify-send "Paper downloaded!"
-		echo $(tput setaf 2)"Done!"$(tput sgr0)
+		echo "${_GREEN}Done!$_RESET"
 		rm /tmp/scitopdf_curl.txt &>/dev/null
 		unset download_link
 		if [ $(echo $automatically_open) = "yes" ]; then
@@ -185,7 +195,7 @@ if ! [[ $(echo "$concatenate") = "" ]]; then
 #		exit 1;
 	fi
 else
-	echo $(tput bold)"Paper to search $(tput sgr0)[title, author, year, DOI, journal, URL...] : "
+	echo "${_BOLD}Paper to search ${_RESET}[title, author, year, DOI, journal, URL...] : "
 	read concatenate
 	paper_search
 fi
@@ -206,17 +216,17 @@ if [[ $(echo $1) = "-l" || $(echo $1) = "--list" ]]; then
 		if [[ "$concatenate" == "" ]]; then
 			continue
 		fi
-		ref_index=$(( $ref_index + 1 )); paper_search "$line"; done < $2
-	echo -e "$(tput setf 3)\n>> End of file \"$2\"	$(tput sgr0)"
-	[[ ! $not_found == 0 ]] && echo -e "$(tput setf 3)$not_found out of $ref_index references not found.$(tput sgr0)"
-	[[ $not_found == 0 ]] && echo -e "$(tput setf 3)$ref_index out of $ref_index references found !$(tput sgr0)"
+		ref_index=$(( ref_index + 1 )); paper_search "$line"; done < $2
+	echo -e "${_YELLOW}\n>> End of file \"$2\"${_RESET}"
+	[[ ! $not_found == 0 ]] && echo -e "${_YELLOW}$not_found out of $ref_index references not found.$_RESET"
+	[[ $not_found == 0 ]] && echo -e "${_YELLOW}$ref_index out of $ref_index references found !$_RESET"
 	exit 1
 else
 	# If no option specified, then every word following scitopdf is considered as the title
 	args=("$@")
 	ELEMENTS=${#args[@]}
 	for (( i=0;i<$ELEMENTS;i++)); do
-	    concatenate=$(echo $concatenate" ")$(echo -n ${args[${i}]}"\ ")
+		concatenate=$(echo $concatenate" ")$(echo -n ${args[${i}]}"\ ")
 	done
 fi
 
@@ -233,9 +243,9 @@ if [[ $(echo $concatenate | grep -io http) == "http" ]]; then
 		echo -e "Paper not found. \nPlease be sure your country is not blocking access to Sci-Hub. \nUse a VPN if possible."
 		[[ ! -v listing ]] && exit;
 	else
-		echo $(tput bold)"Downloading ..."$(tput sgr0)
+		echo "${_BOLD}Downloading ...$_RESET"
 		curl "$download_link" --output "$filename" --progress-bar
-		echo $(tput setaf 2)"Done!"$(tput sgr0)
+		echo "${_GREEN}Done!$_RESET"
 		rm /tmp/scitopdf_curl.txt &>/dev/null
 		unset download_link
 		if [ $(echo $automatically_open) = "yes" ]; then


### PR DESCRIPTION
Not only does this makes the code more readable, `tput` only runs when generating the variables.

This commit also adds a couple of extra variables in case they become useful in the future.